### PR TITLE
service: Always generate cert on start

### DIFF
--- a/service/cert.go
+++ b/service/cert.go
@@ -58,8 +58,11 @@ func deleteCertificate(cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(certPath); os.IsNotExist(err) {
+	if _, err := os.Stat(certPath); err == nil {
+		return os.Remove(certPath)
+	} else if os.IsNotExist(err) {
 		return nil
+	} else {
+		return err
 	}
-	return os.Remove(certPath)
 }

--- a/service/cert.go
+++ b/service/cert.go
@@ -9,15 +9,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// generateCertificate generates a certificate key.
-func generateCertificate(cfg *Config) (*keys.CertificateKey, error) {
+// GenerateCertificate generates a certificate key and saves it to the support dir.
+func GenerateCertificate(cfg *Config, save bool) (*keys.CertificateKey, error) {
 	logger.Infof("Generating certificate...")
 	certKey, err := keys.GenerateCertificateKey("localhost", true, nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := saveCertificate(cfg, certKey.Public()); err != nil {
-		return nil, errors.Wrapf(err, "failed to save cert public key")
+	if save {
+		if err := saveCertificate(cfg, certKey.Public()); err != nil {
+			return nil, errors.Wrapf(err, "failed to save cert public key")
+		}
 	}
 	return certKey, nil
 }
@@ -52,8 +54,8 @@ func loadCertificate(cfg *Config) (string, error) {
 	return string(b), nil
 }
 
-// deleteCertificate removes saved certificate.
-func deleteCertificate(cfg *Config) error {
+// DeleteCertificate removes saved certificate.
+func DeleteCertificate(cfg *Config) error {
 	certPath, err := cfg.certPath(false)
 	if err != nil {
 		return err

--- a/service/cert_test.go
+++ b/service/cert_test.go
@@ -19,13 +19,13 @@ func TestCertificate(t *testing.T) {
 	require.NoError(t, err)
 	err = saveCertificate(cfg, certKey.Public())
 	require.NoError(t, err)
-	defer func() { _ = deleteCertificate(cfg) }()
+	defer func() { _ = DeleteCertificate(cfg) }()
 
 	cert, err = loadCertificate(cfg)
 	require.NoError(t, err)
 	require.NotEmpty(t, cert)
 
-	err = deleteCertificate(cfg)
+	err = DeleteCertificate(cfg)
 	require.NoError(t, err)
 
 	cert, err = loadCertificate(cfg)

--- a/service/keysd/main_test.go
+++ b/service/keysd/main_test.go
@@ -26,7 +26,9 @@ func TestServiceFn(t *testing.T) {
 		Date:    date,
 	}
 	lgi := service.NewLogrusInterceptor(logrus.StandardLogger())
-	serveFn, closeFn, serviceErr := service.NewServiceFn(cfg, build, lgi)
+	cert, err := service.GenerateCertificate(cfg, false)
+	require.NoError(t, err)
+	serveFn, closeFn, serviceErr := service.NewServiceFn(cfg, build, cert, lgi)
 	require.NoError(t, serviceErr)
 
 	t.Logf("testing")

--- a/service/run.go
+++ b/service/run.go
@@ -180,7 +180,7 @@ func NewServiceFn(cfg *Config, build Build, lgi LogInterceptor) (ServeFn, CloseF
 		return nil, nil, err
 	}
 
-	cert, err := certificateKey(cfg, st, true)
+	cert, err := generateCertificate(cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/service/run.go
+++ b/service/run.go
@@ -163,13 +163,13 @@ func runService(cfg *Config, build Build, lgi LogInterceptor) error {
 		return errors.Errorf("port %d in use; is keysd already running?", cfg.Port())
 	}
 
-	cert, err := generateCertificate(cfg)
+	cert, err := GenerateCertificate(cfg, true)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = deleteCertificate(cfg) }()
+	defer func() { _ = DeleteCertificate(cfg) }()
 
-	serveFn, closeFn, serveErr := newServiceFn(cfg, build, cert, lgi)
+	serveFn, closeFn, serveErr := NewServiceFn(cfg, build, cert, lgi)
 	if serveErr != nil {
 		return serveErr
 	}
@@ -177,7 +177,8 @@ func runService(cfg *Config, build Build, lgi LogInterceptor) error {
 	return serveFn()
 }
 
-func newServiceFn(cfg *Config, build Build, cert *keys.CertificateKey, lgi LogInterceptor) (ServeFn, CloseFn, error) {
+// NewServiceFn ...
+func NewServiceFn(cfg *Config, build Build, cert *keys.CertificateKey, lgi LogInterceptor) (ServeFn, CloseFn, error) {
 	var opts []grpc.ServerOption
 
 	st, err := newKeyringStore(cfg)


### PR DESCRIPTION
I was storing the cert in the keyring. It's safer to generate a new cert on every start.

`keys start` waits for a PID file (which is written after the cert) before connecting so they always connect with the correct cert.
